### PR TITLE
Convert exported report to PSObject and export older reports when the history Id is specified.

### DIFF
--- a/Scan.ps1
+++ b/Scan.ps1
@@ -671,6 +671,11 @@ function Export-NessusScan
         $OutFile,
 
         [Parameter(Mandatory=$false,
+                   ValueFromPipelineByPropertyName=$true)]
+        [Switch]
+        $PSObject,
+
+        [Parameter(Mandatory=$false,
                    Position=3,
                    ValueFromPipelineByPropertyName=$true)]
         [ValidateSet('Vuln_Hosts_Summary', 'Vuln_By_Host', 

--- a/Scan.ps1
+++ b/Scan.ps1
@@ -665,7 +665,7 @@ function Export-NessusScan
         [string]
         $Format,
 
-        [Parameter(Mandatory=$true,
+        [Parameter(Mandatory=$false,
                    ValueFromPipelineByPropertyName=$true)]
         [String]
         $OutFile,
@@ -739,7 +739,15 @@ function Export-NessusScan
 
         foreach($Connection in $ToProcess)
         {
-            $path =  "/scans/$($ScanId)/export"
+            if ($HistoryId)
+            {
+                $path =  "/scans/$($ScanId)/export?history_id=$($HistoryId)"
+            }
+            else
+            {
+                $path =  "/scans/$($ScanId)/export"
+            }
+
             Write-Verbose -Message "Exporting scan with Id of $($ScanId) in $($Format) format."
             $FileID = InvokeNessusRestRequest -SessionObject $Connection -Path $path  -Method 'Post' -Parameter $ExportParams
             if ($FileID -is [psobject])
@@ -758,7 +766,12 @@ function Export-NessusScan
                     }
                     Start-Sleep -Seconds 1
                 }
-                if ($FileStatus.status -eq 'ready')
+                if ($FileStatus.status -eq 'ready' -and $Format -eq 'CSV' -and $PSObject.IsPresent)
+                {
+                    Write-Verbose -Message "Converting report to PSObject"
+                    InvokeNessusRestRequest -SessionObject $Connection -Path "/scans/$($ScanId)/export/$($FileID.file)/download" -Method 'Get' | ConvertFrom-CSV
+                }
+                elseif ($FileStatus.status -eq 'ready')
                 {
                     Write-Verbose -Message "Downloading report to $($OutFile)"
                     InvokeNessusRestRequest -SessionObject $Connection -Path "/scans/$($ScanId)/export/$($FileID.file)/download" -Method 'Get' -OutFile $OutFile


### PR DESCRIPTION
This change will:  
- Changes the mandatory parameter option to `$False` for `$OutFile`.  
- Add `$PSObject` switch to convert reports to PSObject. If it is present and the format is CSV, it will convert the report to a PSObject to be stored in a variable. One can then use manipulate the data and pipe it to Export-CSV or Export-Excel (use `Install-Module ImportExcel` to install this module).
- Check if the history Id was specified and export the report. Currently, even if the history Id is specified, the latest report is exported.