### PR TITLE
Added API Token authentication support

### DIFF
--- a/Posh-Nessus.psm1
+++ b/Posh-Nessus.psm1
@@ -1,8 +1,8 @@
-﻿if (!(Test-Path variable:Global:NessusConn ))
+if (!(Test-Path variable:Global:NessusConn ))
 {
     $Global:NessusConn = New-Object System.Collections.ArrayList
 }
- 
+
  # Variables
  $PermissionsId2Name = @{
     16 = 'Read-Only'
@@ -24,7 +24,7 @@
     2 ='Medium'
     3 ='High'
     4 ='Critical'
- } 
+ }
 
  # Load Functions
 
@@ -70,13 +70,19 @@ function InvokeNessusRestRequest
 
     )
 
-    
+
 
     $RestMethodParams = @{
         'Method'        = $Method
         'URI'           =  "$($SessionObject.URI)$($Path)"
-        'Headers'       = @{'X-Cookie' = "token=$($SessionObject.Token)"}
         'ErrorVariable' = 'NessusUserError'
+    }
+
+    # Add the token header if Credentials are used
+    if ($SessionObject.Credentials) {
+        $RestMethodParams['Headers'] = @{'X-Cookie' = "token=$($SessionObject.Token)"}
+    } else {
+        $RestMethodParams['Headers'] = @{'X-ApiKeys' = "accessKey=$($SessionObject.Token.AccessKey); secretKey=$($SessionObject.Token.SecretKey)"}
     }
 
     if ($Parameter)
@@ -103,9 +109,9 @@ function InvokeNessusRestRequest
     {
         #$RestMethodParams.Uri
         $Results = Invoke-RestMethod @RestMethodParams
-   
+
     }
-    catch [Net.WebException] 
+    catch [Net.WebException]
     {
         [int]$res = $_.Exception.Response.StatusCode
         if ($res -eq 401)
@@ -156,4 +162,3 @@ function InvokeNessusRestRequest
     }
     $Results
 }
-

--- a/Session.ps1
+++ b/Session.ps1
@@ -31,22 +31,21 @@ function New-NessusSession
         [int]
         $Port = 8834,
 
-
         # Credentials for connecting to the Nessus Server
         [Parameter(Mandatory=$true,
-        Position=1,
-        ParameterSetName='Credentials')]
+                   Position=1,
+                   ParameterSetName='Credentials')]
         [Management.Automation.PSCredential]$Credentials,
 
         # API keys (alternative to Credentials)
         [Parameter(Mandatory=$true,
-        Position=1,
-        ParameterSetName='API')]
+                   Position=1,
+                   ParameterSetName='API')]
         [String]$AccessKey,
 
         [Parameter(Mandatory=$true,
-        Position=2,
-        ParameterSetName='API')]
+                   Position=2,
+                   ParameterSetName='API')]
         [String]$SecretKey
     )
 


### PR DESCRIPTION
Made changes to Session.ps1 and Posh-Nessus.psm1 to support the use of API Secretkey/Accesskey authentication in addition to username/password authentication. 

Example (using invalid/discarded API key):
```
> New-NessusSession -ComputerName 'scanner1.local' -Port 8834 -AccessKey '0472a87ffa7e3acc01e5c864bbf008a6bdc84de2af
27dd343a513187ce423093' -SecretKey 'aa7762a5b13ef6cb90ef852755f884ab8cd959944e9dbebdc51bfc8483927d4d'


SessionId : 1
URI       : https://scanner1.local:8834
Token     : {SecretKey, AccessKey}
```

Listing my Credential session and my API session. Both can be used by specifying the respective SessionID. No changes have been made to the way existing functions are used. Technically the API session is not a 'session', but it was the simplest way to add API support without completely rewriting the existing authentication framework:
```
> Get-NessusSession


SessionId : 0
URI       : https://scanner1.local:8834
Token     : 42bde0e16fa5638413d12840813aef72f7abede094e1a6c0

SessionId : 1
URI       : https://scanner1.local:8834
Token     : {SecretKey, AccessKey}
```


